### PR TITLE
Fix MaxPool2d layer

### DIFF
--- a/ch_07_Convolutional_Neural_Network/modules.py
+++ b/ch_07_Convolutional_Neural_Network/modules.py
@@ -59,7 +59,7 @@ class MaxPool2d(nn.Module):
         Kh, Kw = self.kernel_size
         Sh, Sw = self.stride
         # Add padding
-        X_pad = F.pad(X, (self.padding, self.padding, self.padding, self.padding), mode="constant", value=0)
+        X_pad = F.pad(X, (self.padding, self.padding, self.padding, self.padding), mode="constant", value=float("-inf"))
 
         # Define output
         Ho = (H + 2 * self.padding - Kh) // Sh + 1

--- a/tests/test_ch07.py
+++ b/tests/test_ch07.py
@@ -21,7 +21,7 @@ class TestModules:
         lin_new.weight = nn.Parameter(lin_base.weight)
         if bias:
             lin_new.bias = nn.Parameter(lin_base.bias)
-        X = torch.rand(2, in_features)
+        X = torch.randn(2, in_features)
         out_base = lin_base(X)
         out_new = lin_new(X)
         torch.testing.assert_close(out_base, out_new)
@@ -49,7 +49,7 @@ class TestModules:
         """
         pool_base = nn.MaxPool2d(kernel_size, stride, padding)
         pool_new = modules.MaxPool2d(kernel_size, stride, padding)
-        X = torch.rand(in_shape)
+        X = torch.randn(in_shape)
         out_base = pool_base(X)
         out_new = pool_new(X)
         torch.testing.assert_close(out_base, out_new)
@@ -89,7 +89,7 @@ class TestModules:
         conv_new.weight = nn.Parameter(conv_base.weight)
         if bias and conv_base.bias is not None:
             conv_new.bias = nn.Parameter(conv_base.bias)
-        X = torch.rand(batch_size, in_channels, *image_size)
+        X = torch.randn(batch_size, in_channels, *image_size)
         out_base = conv_base(X)
         out_new = conv_new(X)
         torch.testing.assert_close(out_base, out_new)
@@ -134,7 +134,7 @@ class TestModules:
         conv_new.weight = nn.Parameter(conv_base.weight)
         if bias and conv_base.bias is not None:
             conv_new.bias = nn.Parameter(conv_base.bias)
-        X = torch.rand(batch_size, in_channels, *image_size)
+        X = torch.randn(batch_size, in_channels, *image_size)
         out_base = conv_base(X)
         out_new = conv_new(X)
         torch.testing.assert_close(out_base, out_new)
@@ -160,7 +160,7 @@ class TestCNN:
 
         cnn_new.load_state_dict(cnn_base.state_dict())
 
-        X = torch.rand(1, 1, 28, 28)
+        X = torch.randn(1, 1, 28, 28)
         out_base = cnn_base(X)
         out_new = cnn_new(X)
         torch.testing.assert_close(out_base, out_new)

--- a/tests/test_ch08.py
+++ b/tests/test_ch08.py
@@ -252,7 +252,7 @@ class TestModels:
         - GoogLeNet is not included because the d2l chapter diverged from the original paper (no batch norm)
         """
         model = model_cls(num_classes=num_classes)
-        dummy_tensor = torch.rand(1, 3, 224, 224)
+        dummy_tensor = torch.randn(1, 3, 224, 224)
         n = utils.get_parameter_count(model, dummy_tensor, verbose=False)
         assert n == expected_params, f"got {n:,} for model {model.__class__.__name__}, expected {expected_params:,}"
 
@@ -315,6 +315,6 @@ class TestModels:
         - GoogLeNet is not included because the d2l chapter diverged from the original paper (no batch norm)
         """
         model = model_cls(num_classes=num_classes)
-        dummy_tensor = torch.rand(1, 3, 224, 224)
+        dummy_tensor = torch.randn(1, 3, 224, 224)
         flops = utils.get_flop_count(model, dummy_tensor, verbose=False) / 2
         assert flops == pytest.approx(published, rel=0.005)


### PR DESCRIPTION
Closes #8  
The output of the custom MaxPool2d layer did not always match the torch implementation, even if the tests did not fail.

- Changed padding to float('-inf') instead of 0. Otherwise max operations do not work as intended
- Changed tests so that the tensors are created with torch.randn instead of torch.rand, so that they can include negative numbers